### PR TITLE
Fix permission checks in autorole commands to ensure proper role mana…

### DIFF
--- a/src/cogs/role.py
+++ b/src/cogs/role.py
@@ -30,7 +30,7 @@ class RoleCog(commands.Cog):
     @commands.guild_only()
     @app_commands.guild_only()
     @commands.has_permissions(manage_roles=True)
-    @commands.bot_has_permissions(manage_roles=True)
+    @commands.bot_has_guild_permissions(manage_roles=True)
     async def autorole(self, ctx: commands.Context) -> None:
         if ctx.invoked_subcommand:
             return
@@ -74,11 +74,11 @@ class RoleCog(commands.Cog):
     @commands.guild_only()
     @app_commands.guild_only()
     @commands.has_permissions(manage_roles=True)
-    @permissions.maintenance_notice() # This is a placeholder for the maintenance notice
+    @commands.bot_has_guild_permissions(manage_roles=True)
     async def autorole_add_human(self, ctx: commands.Context, role: Role) -> None:
         """Add auto roles to human members"""
 
-        if self.is_role_accessible(role):
+        if not self.is_role_accessible(role):
             return await ctx.send("Seems like the role is higher than mine or not accessible !!", ephemeral=True)
         
 
@@ -108,11 +108,11 @@ class RoleCog(commands.Cog):
     @app_commands.guild_only()
     @app_commands.describe(role="The role to add")
     @commands.has_permissions(manage_roles=True)
-    @permissions.maintenance_notice() # This is a placeholder for the maintenance notice
+    @commands.bot_has_guild_permissions(manage_roles=True)
     async def autorole_add_bot(self, ctx: commands.Context, role: Role) -> None:
         """Add auto roles to bot members"""
 
-        if self.is_role_accessible(ctx.guild.me.top_role):
+        if not self.is_role_accessible(ctx.guild.me.top_role):
             return await ctx.send("Seems like the role is higher than mine or not accessible !!", ephemeral=True)
 
         _autoroles = self.bot.models.GuildAutoRoleModel.findOne(ctx.guild.id)


### PR DESCRIPTION
This pull request updates role management commands in `src/cogs/role.py` to improve permission handling and fix a logical error in role accessibility checks. The changes ensure better compatibility with guild-level permissions and correct the behavior of role accessibility validation.

### Permission Handling Updates:
* Replaced `@commands.bot_has_permissions(manage_roles=True)` with `@commands.bot_has_guild_permissions(manage_roles=True)` in the `autorole` command to align with guild-level permission requirements.
* Updated the `autorole_add_human` and `autorole_add_bot` commands to use `@commands.bot_has_guild_permissions(manage_roles=True)` instead of a placeholder maintenance notice decorator. [[1]](diffhunk://#diff-20a27767045d8524d1f651519ae8859c49c1a582244ed437de9ebf028da43227L77-R81) [[2]](diffhunk://#diff-20a27767045d8524d1f651519ae8859c49c1a582244ed437de9ebf028da43227L111-R115)

### Logical Fixes:
* Corrected the condition in the `autorole_add_human` and `autorole_add_bot` commands to properly handle inaccessible roles. The check now correctly uses `not self.is_role_accessible(...)` to ensure roles higher than the bot's are flagged as inaccessible. [[1]](diffhunk://#diff-20a27767045d8524d1f651519ae8859c49c1a582244ed437de9ebf028da43227L77-R81) [[2]](diffhunk://#diff-20a27767045d8524d1f651519ae8859c49c1a582244ed437de9ebf028da43227L111-R115)…gement